### PR TITLE
feat: case insenstive shc protocol range search

### DIFF
--- a/VaccineCard/VaccineCard/Services/CodeValidationService.swift
+++ b/VaccineCard/VaccineCard/Services/CodeValidationService.swift
@@ -79,7 +79,7 @@ class CodeValidationService {
     }
     
     fileprivate func decodeNumeric(code: String) -> String? {
-        if let range = code.range(of: "shc:/") {
+        if let range = code.range(of: "shc:/", options: .caseInsensitive) {
             let numericCode = String(code[range.upperBound...])
             let jwsNumeric = numericCode.chunks(size: 2)
             var uint16s: [UInt16] = []


### PR DESCRIPTION
Some QR code generators / display apps can only encode the SHC token efficiently if `shc:/` is in upper case, this ensures the validator app can read these encoded QR codes.